### PR TITLE
Adding custom engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,18 @@ alias the gf binary to something else, or `unalias gf` to remove the `git fetch`
 There are some amazing code searching engines out there that can be a better replacement for grep.
 A good example is [the silver searcher](https://github.com/ggreer/the_silver_searcher).
 It's faster (like **way faster**) and presents the results in a more visually digestible manner.
-In order to utilize a different engine, use `-engine` and provide a different tool like so:
+In order to utilize a different engine, add `engine: <other tool>` to the relevant pattern file:
 ```bash
-# Using the silver searcher instead of grep
-gf -engine ag api-keys
+# Using the silver searcher instead of grep for the aws-keys pattern:
+# 1. Adding "ag" engine
+# 2. Removing the E flag which is irrelevant for ag
+{
+  "engine": "ag",
+  "flags": "-Hanr",
+  "pattern": "([^A-Z0-9]|^)(AKIA|A3T|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{12,}"
+}
 ```
-* Note I: Different engines use different flags, so in the example above, the flag `E` has to be removed from the `api-keys.json` file in order of ag to successfully run.
-* Note II: You'd probably want to `alias <command>='gf -engine <engine>'` if you plan to use this regularly.
+* Note: Different engines use different flags, so in the example above, the flag `E` has to be removed from the `aws-keys.json` file in order for ag to successfully run.
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ becomes simply:
 The pattern definitions are stored in `~/.gf` as little JSON files that can be kept under version control:
 
 ```
-▶ cat ~/.gf/php-sources.json 
+▶ cat ~/.gf/php-sources.json
 {
     "flags": "-HnrE",
     "pattern": "(\\$_(POST|GET|COOKIE|REQUEST|SERVER|FILES)|php://(input|stdin))"
@@ -83,6 +83,19 @@ source ~/path/to/gf-completion.zsh
 
 Note: if you're using oh-my-zsh or similar you may find that `gf` is an alias for `git fetch`. You can either
 alias the gf binary to something else, or `unalias gf` to remove the `git fetch` alias.
+
+### Using custom engines
+
+There are some amazing code searching engines out there that can be a better replacement for grep.
+A good example is [the silver searcher](https://github.com/ggreer/the_silver_searcher).
+It's faster (like **way faster**) and presents the results in a more visually digestible manner.
+In order to utilize a different engine, use `-engine` and provide a different tool like so:
+```bash
+# Using the silver searcher instead of grep
+gf -engine ag api-keys
+```
+* Note I: Different engines use different flags, so in the example above, the flag `E` has to be removed from the `api-keys.json` file in order of ag to successfully run.
+* Note II: You'd probably want to `alias <command>='gf -engine <engine>'` if you plan to use this regularly.
 
 
 ## Install

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ type pattern struct {
 	Flags    string   `json:"flags,omitempty"`
 	Pattern  string   `json:"pattern,omitempty"`
 	Patterns []string `json:"patterns,omitempty"`
+	Engine   string   `json:"engine,omitempty"`
 }
 
 func main() {
@@ -27,9 +28,6 @@ func main() {
 
 	var dumpMode bool
 	flag.BoolVar(&dumpMode, "dump", false, "prints the grep command rather than executing it")
-
-	var engine string
-	flag.StringVar(&engine, "engine", "grep", "uses a different engine instead of grep e.g. ag")
 
 	flag.Parse()
 
@@ -102,8 +100,8 @@ func main() {
 	} else {
 		var cmd *exec.Cmd
 		operator := "grep"
-		if engine != "" {
-			operator = engine
+		if pat.Engine != "" {
+			operator = pat.Engine
 		}
 
 		if stdinIsPipe() {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,9 @@ func main() {
 	var dumpMode bool
 	flag.BoolVar(&dumpMode, "dump", false, "prints the grep command rather than executing it")
 
+	var engine string
+	flag.StringVar(&engine, "engine", "grep", "uses a different engine instead of grep e.g. ag")
+
 	flag.Parse()
 
 	if listMode {

--- a/main.go
+++ b/main.go
@@ -96,15 +96,20 @@ func main() {
 	}
 
 	if dumpMode {
-		fmt.Printf( "grep --color %v %q %v\n", pat.Flags, pat.Pattern, files )
+		fmt.Printf("grep --color %v %q %v\n", pat.Flags, pat.Pattern, files)
 		//fmt.Println( "grep --color", pat.Flags, pat.Pattern, files)
 
 	} else {
 		var cmd *exec.Cmd
+		operator := "grep"
+		if engine != "" {
+			operator = engine
+		}
+
 		if stdinIsPipe() {
-			cmd = exec.Command("grep", "--color", pat.Flags, pat.Pattern)
+			cmd = exec.Command(operator, "--color", pat.Flags, pat.Pattern)
 		} else {
-			cmd = exec.Command("grep", "--color", pat.Flags, pat.Pattern, files)
+			cmd = exec.Command(operator, "--color", pat.Flags, pat.Pattern, files)
 		}
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
Adding the ability to use a custom code searcher like https://github.com/ggreer/the_silver_searcher.

I use `ag` regularly instead of grep. It's faster and easier visually so I created this small addition.
The only important thing to note is having the flags set up in the .gf json file. Tried to make it clear as possible in the readme. 

I hope you'll like it!