### PR TITLE
zsh completition for file names

### DIFF
--- a/gf-completion.zsh
+++ b/gf-completion.zsh
@@ -1,5 +1,5 @@
 compdef _gf gf
 
-function _gf {
-    _arguments "1: :($(gf -list))"
+function _gf() {
+	_arguments "1: :($(gf -list))" "2: :($(ls))"
 }


### PR DESCRIPTION
As of now, zsh completion only works for the list of patterns. The file name must still be typed manually due to lack of completion.

This pull request solves that.