### PR TITLE
Force stdin when grepping piped data

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 		}
 
 		if stdinIsPipe() {
-			cmd = exec.Command(operator, pat.Flags, pat.Pattern)
+			cmd = exec.Command(operator, pat.Flags, pat.Pattern, "-")
 		} else {
 			cmd = exec.Command(operator, pat.Flags, pat.Pattern, files)
 		}


### PR DESCRIPTION
According to the grep man page: If no FILE is given, recursive searches examine the working directory, and nonrecursive searches read standard input.

In the case of gf, most patterns usually use the recursive flag which will prevent gf to work as expected when piping data to it. This commit fixes this behavior, forcing grep to process stdin even when the recursive flag is used.