### PR TITLE
Fixed -dump flag output and improved search engine argument parsing.

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,11 +104,15 @@ func main() {
 	} else {
 		var cmd *exec.Cmd
 
-		if stdinIsPipe() {
-			cmd = exec.Command(operator, pat.Flags, pat.Pattern)
-		} else {
-			cmd = exec.Command(operator, pat.Flags, pat.Pattern, files)
+		// combining flags, patterns and files into single slice
+		arguments := strings.Fields(pat.Flags)
+		arguments = append(arguments, pat.Pattern)
+
+		if !stdinIsPipe() {
+			arguments = append(arguments, files)
 		}
+
+		cmd = exec.Command(operator, arguments...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/main.go
+++ b/main.go
@@ -92,16 +92,17 @@ func main() {
 
 		pat.Pattern = "(" + strings.Join(pat.Patterns, "|") + ")"
 	}
+	
+	operator := "grep"
+	if pat.Engine != "" {
+		operator = pat.Engine
+	}
 
 	if dumpMode {
-		fmt.Printf("grep %v %q %v\n", pat.Flags, pat.Pattern, files)
+		fmt.Printf("%v %v %q %v\n", operator, pat.Flags, pat.Pattern, files)
 
 	} else {
 		var cmd *exec.Cmd
-		operator := "grep"
-		if pat.Engine != "" {
-			operator = pat.Engine
-		}
 
 		if stdinIsPipe() {
 			cmd = exec.Command(operator, pat.Flags, pat.Pattern)


### PR DESCRIPTION
- Changed `-dump` flag output to show the custom engine (if configured), rather than always showing `grep`.
- Fixed handling of the "flags" JSON field when multiple (space-separated) command line arguments are given.