### PR TITLE
Fix documentation so src dir will exist after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ In order to utilize a different engine, add `engine: <other tool>` to the releva
 If you've got Go installed and configured you can install `gf` with:
 
 ```
-▶ go get -u github.com/tomnomnom/gf
+▶ GO111MODULE=off go get -v github.com/tomnomnom/gf
 ```
 
 If you've installed using `go get`, you can enable auto-completion to your `.bashrc` like this:


### PR DESCRIPTION
At the moment, the documentation suggests installing `gf` with `go get ...`, but without the prefix `GO111MODULE=off` it won't fetch the src directory, therefore the autocomplete won't work as well.