### PR TITLE
Update installation method of gf using GO.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ In order to utilize a different engine, add `engine: <other tool>` to the releva
 If you've got Go installed and configured you can install `gf` with:
 
 ```
-▶ go get -u github.com/tomnomnom/gf
+▶ go install github.com/tomnomnom/gf@latest
 ```
 
 If you've installed using `go get`, you can enable auto-completion to your `.bashrc` like this:


### PR DESCRIPTION
Installing executables with 'go get' in module mode is deprecated, so we need to use 'go install' instead of 'go get'. So, updated the installation method accordingly in README document.