### PR TITLE
Changed the method of installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ In order to utilize a different engine, add `engine: <other tool>` to the releva
 If you've got Go installed and configured you can install `gf` with:
 
 ```
-▶ go get -u github.com/tomnomnom/gf
+▶ go install github.com/tomnomnom/gf@latest
 ```
 
 If you've installed using `go get`, you can enable auto-completion to your `.bashrc` like this:


### PR DESCRIPTION
Go get has been depreciated in GO 1.17 , so now GO GET allows you to install executables ! 