### PR TITLE
small change could make difference

### DIFF
--- a/examples/urls.json
+++ b/examples/urls.json
@@ -1,4 +1,4 @@
 {
 	"flags": "-oriahE",
-	"pattern": "https?://[^\"\\'> ]+"
+	"pattern": "https?:\/\/[^\"\\'> ]+"
 }


### PR DESCRIPTION
 If gf is  `A wrapper around grep`  then you have to know that it uses PCRE lib and `/` char must be escaped